### PR TITLE
Move to broccoli plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,8 +16,8 @@ function Dereference(inputNode, options) {
   this.options = options;
 }
 
-Dereference.prototype.constructor = Dereference;
 Dereference.prototype = Object.create(Plugin.prototype);
+Dereference.prototype.constructor = Dereference;
 
 Dereference.prototype.build = function () {
   // copyDereferenceSync wants to create the directory.

--- a/index.js
+++ b/index.js
@@ -1,24 +1,26 @@
 var copyDereferenceSync = require('copy-dereference').sync;
 var rimraf = require('rimraf');
-var Writer = require("broccoli-writer");
+var Plugin = require("broccoli-plugin");
 
 module.exports = Dereference;
 
-function Dereference(inputTree) {
+function Dereference(inputNode, options) {
   if (!(this instanceof Dereference)) {
-    return new Dereference(inputTree);
+    return new Dereference(inputNode, options);
   }
-  this.inputTree = inputTree;
+
+  options = options || {};
+  Plugin.call(this, [inputNode], {
+    annotation: options.annotation
+  })
+  this.options = options;
 }
 
 Dereference.prototype.constructor = Dereference;
-Dereference.prototype = Object.create(Writer.prototype);
+Dereference.prototype = Object.create(Plugin.prototype);
 
-Dereference.prototype.write = function (readTree, destDir) {
-  return readTree(this.inputTree)
-      .then(function (srcDir) {
-        // copyDereferenceSync wants to create the directory.
-        rimraf.sync(destDir);
-        copyDereferenceSync(srcDir, destDir);
-      });
+Dereference.prototype.build = function () {
+  // copyDereferenceSync wants to create the directory.
+  rimraf.sync(this.outputPath);
+  copyDereferenceSync(this.inputPaths[0], this.outputPath);
 };

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "symlink"
   ],
   "dependencies": {
-    "broccoli-writer": "^0.1.1",
+    "broccoli-plugin": "^1.0.0",
     "copy-dereference": "^1.0.0",
     "rimraf": "^2.2.8"
   },


### PR DESCRIPTION
I had to do this so that broccoli-dereference would no longer have a different output directory every rebuild (and allow for easier integration with other custom plugins). So I figured I'd PR upstream while I was at it.
